### PR TITLE
(feat) login/signup feature fully replaced with spotify authentication

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -4,8 +4,9 @@ mongoose.Promise = require('bluebird');
 mongoose.createConnection('mongodb://localhost/test');
 const config = require('../config/index.js');
 const DATABASE_URL = config.DATABASE_URL;
+const findOrCreate = require('mongoose-find-or-create');
 
- mongoose.connect(DATABASE_URL);
+mongoose.connect(DATABASE_URL);
 const db = mongoose.connection;
 
 db.on('error', (err) => {
@@ -68,6 +69,7 @@ let userSchema = mongoose.Schema({
   songs: [Number]
 });
 userSchema.plugin(beautifyUnique);
+userSchema.plugin(findOrCreate);
 const User = mongoose.model('User', userSchema);
 
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mongodb": "^2.2.26",
     "mongoose": "^4.9.7",
     "mongoose-beautiful-unique-validation": "^5.1.1",
+    "mongoose-find-or-create": "^1.3.0",
     "nodemon": "^1.11.0",
     "passport": "^0.3.2",
     "passport-spotify": "^0.3.1",

--- a/react-client/src/components/User.jsx
+++ b/react-client/src/components/User.jsx
@@ -66,11 +66,8 @@ class User extends React.Component {
         <div className="user">
           {renderif(!this.state.loggedIn)(
             <div>
-              <div className="loginButton" onClick={this.redirect}>
-                Login/Signup!
-              </div>
-              <a href="http://localhost:8080/auth/spotify" className="loginButton" onClick={this.loginSpotify}>
-              Spotify
+              <a href="http://localhost:8080/auth/spotify" className="loginButton">
+              Connect With Spotify
               </a>
             </div>
           )}
@@ -79,10 +76,16 @@ class User extends React.Component {
               Logout!
             </div>
           )}
-          {renderif(this.state.loggedIn)(<PastSearches search={this.props.search} prev={this.props.prev} upDown={this.props.upDown} runUpDown={this.props.runUpDown} pastSearch={this.pastSearch}/>)}
+          {renderif(this.state.loggedIn)(<PastSearches search={this.props.search} 
+                                                       prev={this.props.prev} 
+                                                       upDown={this.props.upDown} 
+                                                       runUpDown={this.props.runUpDown} 
+                                                       pastSearch={this.pastSearch}/>)}
         </div>
         <div>
-          <br/> {renderif(this.props.showPrev)(<PastSearchResults results={this.state.pastSearchResults} loading={this.state.loading} loadPastSearchResults={this.props.loadPastSearchResults}/>)}
+          <br/> {renderif(this.props.showPrev)(<PastSearchResults results={this.state.pastSearchResults} 
+                                                                  loading={this.state.loading} 
+                                                                  loadPastSearchResults={this.props.loadPastSearchResults}/>)}
         </div>
       </div>
     );
@@ -90,3 +93,17 @@ class User extends React.Component {
 }
 
 export default User;
+
+
+
+//If we want to re-add signing up feaure(?)
+// {renderif(!this.state.loggedIn)(
+//   <div>
+//     <div className="loginButton" onClick={this.redirect}>
+//       Login/Signup!
+//     </div>
+//     <a href="http://localhost:8080/auth/spotify" className="loginButton">
+//     Connect With Spotify
+//     </a>
+//   </div>
+// )}

--- a/server/app.js
+++ b/server/app.js
@@ -23,7 +23,6 @@ const config = require('../config/index.js');
 
 
 passport.serializeUser(function(user, done) {
-  // console.log('serialized user: ', user);
   done(null, user);
 });
 
@@ -41,21 +40,16 @@ passport.use(new SpotifyStrategy({
   callbackURL: config.SPOTIFY.cbURL
   },
   function(accessToken, refreshToken, profile, done) {
-
-    let url = `https://api.spotify.com/v1/users/${profile.id}/playlists`
-    // let options = {
-    //   url: url,
-    //   headers: {"Authorization": 'Bearer ' + accessToken}
-    // }
-
-    axios.get(url, { 'headers': { 'Authorization': `Bearer ${accessToken}` } })
-
-      .then((res) => {
-        console.log('received playlists from spotify: ', res.data.items);
-      })
-      .catch((err) => {
-        console.log('error retrieving playlists from spotify ', err);
-      })
+    /* CREATE A USER HERE SO THERE IS NO NEED TO EVER "SIGN UP" */
+    
+    // let url = `https://api.spotify.com/v1/users/${profile.id}/playlists`;
+    // axios.get(url, { 'headers': { 'Authorization': `Bearer ${accessToken}` } })
+    //   .then((res) => {
+    //     console.log('received playlists from spotify: ', res.data.items);
+    //   })
+    //   .catch((err) => {
+    //     console.log('error retrieving playlists from spotify ', err);
+    //   })
     done(null, profile);
   }
   ));
@@ -75,6 +69,25 @@ app.use(express.static(__dirname + '/../react-client/dist'));
 // routes
 let sess = {};
 
+
+
+app.get('/auth/spotify',
+  passport.authenticate('spotify', {scope: ['user-read-email'], showDialog: true}),
+  (req, res) => {
+    console.log('You fucked up, this should not be called');
+  });
+
+app.get('/auth/spotify/callback',
+  passport.authenticate('spotify', { failureRedirect: '/login' }),
+  (req, res) => {
+    res.redirect('/');
+  });
+
+
+
+
+
+
 var spotifyApi = new SpotifyWebApi({clientId: config.SPOTIFY_CLIENT_API_KEY, clientSecret: config.SPOTIFY_CLIENT_SECRET_API_KEY});
 spotifyApi.clientCredentialsGrant()
  .then(function(data) {
@@ -86,83 +99,57 @@ spotifyApi.clientCredentialsGrant()
    console.log('Something went wrong when retrieving an access token', err.message);
  });
 
-app.get('/auth/spotify',
-  passport.authenticate('spotify', {scope: ['user-read-email'], showDialog: true}),
-  (req, res) => {
-    console.log('You fucked up, this should not be called');
-  });
-
-app.get('/auth/spotify/callback',
-  passport.authenticate('spotify', { failureRedirect: '/login' }),
-  (req, res) => {
-    console.log('Successfully authenticated with Spotify');
-
-    res.redirect('/');
-  });
-
-
-
-
-
-
-
 
 app.post('/signup', auth.createUser, (req, res) => {
-  console.log('signing up');
   sess = req.session;
   sess.username = req.body.username;
   res.send({statusCode: 200});
 });
 
 app.post('/login', auth.verifyUser, (req, res) => {
-  console.log('logging in');
   sess = req.session;
   sess.username = req.body.username;
   res.send({statusCode: 200});
 });
 
+//modified check
 app.get('/check', (req, res) => {
-  console.log('checking something');
-  if (req.session.username) {
-    console.log('cool')
+  if (req.session.username || req.session.passport) {
+    console.log('cool!!!!')
     res.send({statusCode: 200});
   } else {
-    console.log('I mdskjhfkjhdfkjshd')
     res.send({statusCode: 404});
   }
 })
 
 
 app.get('/logout', (req, res) => {
-  console.log('logging out');
-  console.log('logging out');
   req.session.destroy()
   res.send('logged out!')
 })
 
  app.get('/newreleases', (req,res) => {
-   spotifyApi.getNewReleases({ limit : 20, offset: 0, country: 'US' })
-     .then(data => {
-        topTenData = {
-          songs: data.body.albums.items,
-          dateadded: Date.now()
-        };
-      const newTopTenEntry = new db.TopTenSongs(topTenData);
-      newTopTenEntry.save(err => {
-        if (err) {console.log('Error saving TopTenSong data')}
-          })
-       res.send(data.body.albums.items);
-     });
+   // spotifyApi.getNewReleases({ limit : 10, offset: 0, country: 'US' })
+   //   .then(data => {
+   //      topTenData = {
+   //        songs: data.body.albums.items,
+   //        dateadded: Date.now()
+   //      };
+   //    const newTopTenEntry = new db.TopTenSongs(topTenData);
+   //    newTopTenEntry.save(err => {
+   //      if (err) {console.log('Error saving TopTenSong data')}
+   //        })
+   //     res.send(data.body.albums.items);
+   //   });
 
-     }, function(err) {
-       console.log("could not get new releases", err);
+   //   }, function(err) {
+   //     console.log("could not get new releases", err);
    });
 
 
 
 
 app.post('/search', (req, res) => {
-  console.log('searching');
   return mmHelpers.searchByTitleAndArtist(req.body.title, req.body.artist)
   .then(data => {
     if (data.track_list.length === 0) { res.send({errorMessage: 'No Search Results'}); }
@@ -172,7 +159,6 @@ app.post('/search', (req, res) => {
 });
 
 app.post('/fetchLyricsByTrackId', (req, res) => {
-  console.log('getting lyrics by track id');
   const trackId = req.body.trackId;
   return mmHelpers.getLyricsByTrackId(trackId)
   .then(lyrics => {
@@ -182,7 +168,6 @@ app.post('/fetchLyricsByTrackId', (req, res) => {
 });
 
 app.post('/process', (req, res) => {
-  console.log('process');
   let input = req.body;
   const songNameAndArtist = [input.artist_name, input.track_name];
   let watsonData = {};
@@ -245,12 +230,11 @@ app.post('/process', (req, res) => {
 })
 
 app.get('/pastSearches', (req, res) => {
-  console.log('pastSearches');
-  const username = req.session.username;
+  const username = req.session.username || req.session.passport.username;
   return new Promise ((resolve, reject) => {
     db.User.where({ username: username }).findOne((err, user) => {
       if (err) { reject(err); }
-      const songs = user.songs;
+      const songs = user !== null ? user.songs : [];
       resolve(songs);
     })
   })
@@ -280,7 +264,6 @@ app.get('/pastSearches', (req, res) => {
 });
 
 app.post('/loadPastSearchResults', (req, res) => {
-  console.log('load pas things');
   return new Promise((resolve, reject) => {
     db.Song
     .find({ track_id: req.body.track_id })


### PR DESCRIPTION
Connect with spotify button now handles the same functionality that
signing up/logging in did. The schema needs to be refactored to find or create
a user upon authentication from spotify. =>

This will affect how songs/watson info gets "saved" when searching
as a logged in user